### PR TITLE
reverse try/except to avoid deprecation warning

### DIFF
--- a/pinax/ratings/models.py
+++ b/pinax/ratings/models.py
@@ -8,9 +8,9 @@ from django.utils.encoding import python_2_unicode_compatible
 
 from django.contrib.auth.models import User
 try:
-    from django.contrib.contenttypes.generic import GenericForeignKey
-except:
     from django.contrib.contenttypes.fields import GenericForeignKey
+except:
+    from django.contrib.contenttypes.generic import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 
 from .categories import RATING_CATEGORY_CHOICES


### PR DESCRIPTION
This reverses the order of the try/except statement so that the deprecation warning doesn't appear.