### PR TITLE
Fix rate_count tag to exclude ratings of zero, aka unrated

### DIFF
--- a/pinax/ratings/templatetags/pinax_ratings_tags.py
+++ b/pinax/ratings/templatetags/pinax_ratings_tags.py
@@ -189,7 +189,7 @@ def user_rating_url(user, obj):
 @register.simple_tag
 def rating_count(obj):
     """
-    Total amount of users who have submitted a rating for this object.
+    Total amount of users who have submitted a positive rating for this object.
 
     Usage:
         {% rating_count obj %}
@@ -197,5 +197,5 @@ def rating_count(obj):
     count = Rating.objects.filter(
         object_id=obj.pk,
         content_type=ContentType.objects.get_for_model(obj),
-    ).count()
+    ).exclude(rating=0).count()
     return count


### PR DESCRIPTION
A `Rating` object may contain 0 as its rating which should not count towards the total rate count.