### PR TITLE
Refactor overall_rating and user_rating tag as built in Django simple…

### DIFF
--- a/pinax/ratings/templatetags/pinax_ratings_tags.py
+++ b/pinax/ratings/templatetags/pinax_ratings_tags.py
@@ -36,110 +36,38 @@ def user_rating_value(user, obj, category=None):
     return rating
 
 
-class UserRatingNode(template.Node):
-
-    @classmethod
-    def handle_token(cls, parser, token):
-        bits = token.split_contents()
-
-        if len(bits) == 5:
-            category = None
-        elif len(bits) == 6:
-            category = parser.compile_filter(bits[3])
-        else:
-            raise template.TemplateSyntaxError()
-
-        return cls(
-            user=parser.compile_filter(bits[1]),
-            obj=parser.compile_filter(bits[2]),
-            as_var=bits[len(bits) - 1],
-            category=category
-        )
-
-    def __init__(self, user, obj, as_var, category=None):
-        self.user = user
-        self.obj = obj
-        self.as_var = as_var
-        self.category = category
-
-    def render(self, context):
-        user = self.user.resolve(context)
-        obj = self.obj.resolve(context)
-        if self.category:
-            category = self.category.resolve(context)
-        else:
-            category = None
-        context[self.as_var] = user_rating_value(user, obj, category)
-        return ""
-
-
-@register.tag
-def user_rating(parser, token):
+@register.simple_tag
+def user_rating(user, object, category=None):
     """
     Usage:
         {% user_rating user obj [category] as var %}
     """
-    return UserRatingNode.handle_token(parser, token)
+    return user_rating_value(user, object, category)
 
 
-class OverallRatingNode(template.Node):
-
-    @classmethod
-    def handle_token(cls, parser, token):
-        bits = token.split_contents()
-
-        if len(bits) == 4:
-            category = None
-        elif len(bits) == 5:
-            category = parser.compile_filter(bits[2])
-        else:
-            raise template.TemplateSyntaxError()
-
-        return cls(
-            obj=parser.compile_filter(bits[1]),
-            as_var=bits[len(bits) - 1],
-            category=category
-        )
-
-    def __init__(self, obj, as_var, category=None):
-        self.obj = obj
-        self.as_var = as_var
-        self.category = category
-
-    def render(self, context):
-        obj = self.obj.resolve(context)
-        if self.category:
-            category = self.category.resolve(context)
-        else:
-            category = None
-
-        try:
-            ct = ContentType.objects.get_for_model(obj)
-            if category is None:
-                rating = OverallRating.objects.filter(
-                    object_id=obj.pk,
-                    content_type=ct
-                ).aggregate(r=models.Avg("rating"))["r"]
-                rating = Decimal(str(rating or "0"))
-            else:
-                rating = OverallRating.objects.get(
-                    object_id=obj.pk,
-                    content_type=ct,
-                    category=category_value(obj, category)
-                ).rating or 0
-        except OverallRating.DoesNotExist:
-            rating = 0
-        context[self.as_var] = rating
-        return ""
-
-
-@register.tag
-def overall_rating(parser, token):
+@register.simple_tag
+def overall_rating(object, category=None):
     """
     Usage:
         {% overall_rating obj [category] as var %}
     """
-    return OverallRatingNode.handle_token(parser, token)
+    try:
+        ct = ContentType.objects.get_for_model(object)
+        if category is None:
+            rating = OverallRating.objects.filter(
+                object_id=object.pk,
+                content_type=ct
+            ).aggregate(r=models.Avg("rating"))["r"]
+            rating = Decimal(str(rating or "0"))
+        else:
+            rating = OverallRating.objects.get(
+                object_id=object.pk,
+                content_type=ct,
+                category=category_value(object, category)
+            ).rating or 0
+    except OverallRating.DoesNotExist:
+        rating = 0
+    return rating
 
 
 def rating_post_url(user, obj):
@@ -168,7 +96,7 @@ def user_rating_js(user, obj, category=None):
     }
 
 
-@register.assignment_tag
+@register.simple_tag
 def ratings(obj):
     ct = ContentType.objects.get_for_model(obj)
     try:


### PR DESCRIPTION
…_tag

assignment-tags has been deprecated since version 1.9:
simple_tag can now store results in a template variable and should be used instead.
https://docs.djangoproject.com/en/1.9/howto/custom-template-tags/#assignment-tags

ratings tags as also been replace with simple_tag

Closes #30 #31