### PR TITLE
Fix TypeError when call str() on ratings

### DIFF
--- a/pinax/ratings/models.py
+++ b/pinax/ratings/models.py
@@ -93,4 +93,4 @@ class Rating(models.Model):
         ]
 
     def __str__(self):
-        return self.rating
+        return str(self.rating)


### PR DESCRIPTION
Small Fixes following error:

`TypeError: __str__ returned non-string (type int)`

Generated (e.g.) when viewing objects a user has created.